### PR TITLE
1.0 Compatability

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This module defines two data types for working with graphs:
 
 To get started, get the package like this:
 ```julia
-Pkg.clone("https://github.com/scheinerman/SimpleGraphs.jl.git")
+]clone https://github.com/scheinerman/SimpleGraphs.jl.git
 ```
 Then, in any Julia session or program, give the command
 `using SimpleGraphs`.

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,8 @@
-julia 0.6
+julia 1.0
+DataStructures
+SimpleRandom
+Primes
+Polynomials
+SimplePartitions
+IterTools
+Graphs

--- a/doc/SimpleGraph.tex
+++ b/doc/SimpleGraph.tex
@@ -25,7 +25,7 @@ given Julia data type, which might be \verb|Any|.
 
 To begin, get the repository with this Julia command:
 \begin{verbatim}
-Pkg.clone("https://github.com/scheinerman/SimpleGraphs.jl.git")
+] clone https://github.com/scheinerman/SimpleGraphs.jl.git
 \end{verbatim}
 This only has to be done once. To use the \verb|SimpleGraph| type,
 give the command \verb|using SimpleGraphs|.

--- a/src/d_simple_core.jl
+++ b/src/d_simple_core.jl
@@ -38,7 +38,7 @@ end
 """
 StringDigraph() = SimpleDigraph{String}()
 
-vertex_type{T}(G::SimpleDigraph{T}) = T
+vertex_type(G::SimpleDigraph{T}) where {T} = T
 
 """
 `IntDigraph()` creates a new directed graph with vertices of type
@@ -105,7 +105,7 @@ end
 """
 `loops(G)` returns a list of vertices at which a loop is present.
 """
-function loops{T}(G::SimpleDigraph{T})
+function loops(G::SimpleDigraph{T}) where {T}
     if !is_looped(G)
         return T[]
     end
@@ -118,6 +118,7 @@ function loops{T}(G::SimpleDigraph{T})
     loop_list = collect(loop_set)
     try
         sort!(loop_list)
+    catch
     end
     return loop_list
 end
@@ -168,6 +169,7 @@ function out_neighbors(G::SimpleDigraph, v)
     result = collect(G.N[v])
     try
         sort!(result)
+    catch
     end
     return result
 end
@@ -180,6 +182,7 @@ function in_neighbors(G::SimpleDigraph, v)
     result = collect(G.NN[v])
     try
         sort!(result)
+    catch
     end
     return result
 end
@@ -197,7 +200,7 @@ end
 has(G::SimpleDigraph, v, w) = has(G,v) && in(w,G.N[v])
 
 # Add a vertex to a digraph
-function add!{T}(G::SimpleDigraph{T}, v)
+function add!(G::SimpleDigraph{T}, v) where {T}
     if has(G,v)
         return false
     end
@@ -208,7 +211,7 @@ function add!{T}(G::SimpleDigraph{T}, v)
 end
 
 # Add an edge to a digraph
-function add!{T}(G::SimpleDigraph{T}, v, w)
+function add!(G::SimpleDigraph{T}, v, w) where {T}
     if !G.looped && v==w
         return false
     end
@@ -254,7 +257,7 @@ function delete!(G::SimpleDigraph, v)
 end
 
 # Create a list of all edges in the digraph
-function elist{T}(G::SimpleDigraph{T})
+function elist(G::SimpleDigraph{T}) where {T}
     E = Set{Tuple{T,T}}()
     for v in G.V
         for w in G.N[v]
@@ -264,13 +267,14 @@ function elist{T}(G::SimpleDigraph{T})
     result = collect(E)
     try
         sort!(result)
+    catch
     end
     return result
 end
 
 # Convert a directed graph into a simple undirected graph by removing
 # directions (and loops)
-function simplify{T}(D::SimpleDigraph{T})
+function simplify(D::SimpleDigraph{T}) where {T}
     G = SimpleGraph{T}()
     for v in D.V
         add!(G,v)
@@ -309,7 +313,7 @@ end
 
 # Relabel the vertics of a graph based on a dictionary mapping old
 # vertex names to new
-function relabel{S,T}(G::SimpleDigraph{S}, label::Dict{S,T})
+function relabel(G::SimpleDigraph{S}, label::Dict{S,T}) where {S,T}
     H = SimpleDigraph{T}()
     for v in G.V
         add!(H,label[v])
@@ -325,7 +329,7 @@ function relabel{S,T}(G::SimpleDigraph{S}, label::Dict{S,T})
 end
 
 # Relabel the vertices with the integers 1:n
-function relabel{S}(G::SimpleDigraph{S})
+function relabel(G::SimpleDigraph{S}) where {S}
     verts = vlist(G)
     n = length(verts)
     label = Dict{S,Int}()
@@ -348,7 +352,7 @@ bipartite graph. For each vertex `v` in `G`, the output graph has two
 vertices `(v,1)` and `(v,2)`. Each edge `(v,w)` of `G` is rendered as
 an edge between `(v,1)` and `(w,2)` in the output graph.
 """
-function vertex_split{S}(G::SimpleDigraph{S})
+function vertex_split(G::SimpleDigraph{S}) where {S}
     H = SimpleGraph{Tuple{S,Int}}()
 
     for v in vlist(G)

--- a/src/simple_coloring.jl
+++ b/src/simple_coloring.jl
@@ -10,7 +10,7 @@ export bipartition, two_color, greedy_color, random_greedy_color
 if the graph is not bipartite. The output is a `Dict` mapping the
 vertex set to the values 1 and 2.
 """
-function two_color{T}(G::SimpleGraph{T})
+function two_color(G::SimpleGraph{T}) where {T}
     if cache_check(G,:two_color)
       return cache_recall(G,:two_color)
     end
@@ -47,7 +47,7 @@ using SimplePartitions
 `bipartition(G)` creates a bipartition of the graph (or returns an
 error if the graph is not bipartite. Output is a `Partition`.
 """
-function bipartition{T}(G::SimpleGraph{T})
+function bipartition(G::SimpleGraph{T}) where {T}
   f = two_color(G)
   return Partition(f)
 end
@@ -66,7 +66,7 @@ is returned to you as a `Dict` mapping vertices to positive integers
 
 If `seq` is omitted, a random permutation of the vertices is used.
 """
-function greedy_color{T}(G::SimpleGraph{T}, seq::Array{T,1})
+function greedy_color(G::SimpleGraph{T}, seq::Array{T,1}) where {T}
     f = Dict{T,Int}()  # this is the mapping from V to colors
     maxf::Int = 0      # largest color used
 
@@ -107,7 +107,7 @@ end
 
 # Apply greedy_color to the graph visiting the vertices in decreasing
 # order of degree.
-function greedy_color{T}(G::SimpleGraph{T})
+function greedy_color(G::SimpleGraph{T}) where {T}
     seq = deg_sorted_vlist(G)
     return greedy_color(G,seq)
 end
@@ -122,7 +122,7 @@ end
 random permutations of the vertex set. After `reps` iterations, the
 best coloring found is returned.
 """
-function random_greedy_color{T}(G::SimpleGraph{T}, reps::Int=1)
+function random_greedy_color(G::SimpleGraph{T}, reps::Int=1) where {T}
     n = NV(G)
     bestf = greedy_color(G)  # degree order default start
     best  = maximum(values(bestf))

--- a/src/simple_connect.jl
+++ b/src/simple_connect.jl
@@ -8,7 +8,7 @@ export eccentricity, radius, center
 `components(G)` returns the vertex sets of the connected components of
 `G` (as a `Partition`).
 """
-function components{T}(G::SimpleGraph{T})
+function components(G::SimpleGraph{T}) where {T}
   if cache_check(G,:components)
     return cache_recall(G,:components)
   end
@@ -25,7 +25,7 @@ end
 """
 `num_components(G)` returns the number of connected components in `G`.
 """
-function num_components{T}(G::SimpleGraph{T})::Int
+function num_components(G::SimpleGraph{T})::Int where {T}
   if cache_check(G,:num_components)
     return cache_recall(G,:num_components)
   end
@@ -39,7 +39,7 @@ end
 """
 `is_connected(G)` determines if `G` is connected.
 """
-function is_connected{T}(G::SimpleGraph{T})
+function is_connected(G::SimpleGraph{T}) where {T}
     return num_components(G) <= 1
 end
 
@@ -49,7 +49,7 @@ end
 """
 `spanning_forest(G)` creates a maximal acyclic subgraph of `G`.
 """
-function spanning_forest{T}(G::SimpleGraph{T})
+function spanning_forest(G::SimpleGraph{T}) where {T}
     if cache_check(G,:spanning_forest)
       return cache_recall(G,:spanning_forest)
     end

--- a/src/simple_constructors.jl
+++ b/src/simple_constructors.jl
@@ -99,7 +99,7 @@ function Path(n::Int)
 end
 
 # Create a path graph from a list of vertices
-function Path{T}(verts::Array{T})
+function Path(verts::Array{T}) where {T}
     G = SimpleGraph{T}()
     n = length(verts)
 
@@ -493,7 +493,7 @@ of an edge from a vertex in block `i` to a vertex in block `j`.
 `RandomSBM(n,pvec,pmat)` creates such a graph with `n` vertices. The vector
 `pvec` gives the probabilities that vertices fall into a given block.
 """
-function RandomSBM{S<:Real}(bmap::Vector{Int}, pmat::Array{S,2})
+function RandomSBM(bmap::Vector{Int}, pmat::Array{S,2}) where {S<:Real}
   n = length(bmap)    # no of vertices
   b = maximum(bmap)   # no of blocks
 
@@ -519,7 +519,7 @@ function RandomSBM{S<:Real}(bmap::Vector{Int}, pmat::Array{S,2})
 end
 
 
-function RandomSBM{S<:Real,T<:Real}(n::Int, pvec::Vector{S}, pmat::Array{T,2})
+function RandomSBM(n::Int, pvec::Vector{S}, pmat::Array{T,2}) where {S<:Real,T<:Real}
   @assert minimum(pvec)>=0 "Entries in pvec must be nonnegative"
   @assert sum(pvec)==1 "Entries in pvec must sum to 1"
   bmap = [ random_choice(pvec) for _=1:n]

--- a/src/simple_core.jl
+++ b/src/simple_core.jl
@@ -1,4 +1,4 @@
-import Base.show, Base.==, Base.ctranspose, Base.*
+import Base.show, Base.==, Base.adjoint, Base.*
 import Base.getindex
 
 export SimpleGraph, IntGraph, StringGraph
@@ -76,7 +76,7 @@ or two tokens separated by white space. If the line contains a single
 token, we add that token as a vertex. If the line contains two (or
 more) tokens, then the first two tokens are taken as vertex names and
 (assuming they are different) the corresponding edge is created. Any
-extra tokens on the line are ignored. Lines that begin with a \# are
+extra tokens on the line are ignored. Lines that begin with a # are
 ignored.
 """
 StringGraph() = SimpleGraph{String}()
@@ -160,7 +160,7 @@ SimpleGraph(A::Matrix) = IntGraph(A)
 `vertex_type(G)` returns the data type of the vertices this graph may hold.
 For example, if `G=IntGraph()` then this returns `Int64`.`
 """
-vertex_type{T}(G::SimpleGraph{T}) = T
+vertex_type(G::SimpleGraph{T}) where {T} = T
 
     # number of vertices and edges
 
@@ -194,7 +194,7 @@ structure holding the graph, but slows down look up of edges.
 
 **Note**: Fast neighborhood look up is on by default.
 """
-function fastN!{T}(G::SimpleGraph{T},flg::Bool=true)
+function fastN!(G::SimpleGraph{T},flg::Bool=true) where {T}
     # if no change, do nothing
     if flg == G.Nflag
         return flg
@@ -247,6 +247,7 @@ function vlist(G::AbstractSimpleGraph)
     result = collect(G.V)
     try
         sort!(result)
+    catch
     end
     return result
 end
@@ -258,6 +259,7 @@ function elist(G::SimpleGraph)
     result = collect(G.E)
     try
         sort!(result)
+    catch
     end
     return result
 end
@@ -268,7 +270,7 @@ end
 
 May also be invoked as `G[v]`.
 """
-function neighbors{T}(G::SimpleGraph{T}, v)
+function neighbors(G::SimpleGraph{T}, v) where {T}
     if ~has(G,v)
         error("Graph does not contain requested vertex")
     end
@@ -286,6 +288,7 @@ function neighbors{T}(G::SimpleGraph{T}, v)
     end
     try
         sort!(N)
+    catch
     end
     return N
 end
@@ -314,7 +317,7 @@ function deg(G::SimpleGraph, v)
 end
 
 # Degree sequence
-function deg{T}(G::SimpleGraph{T})
+function deg(G::SimpleGraph{T}) where {T}
     if G.Nflag
         ds = [deg(G,v) for v in G.V]
     else
@@ -344,7 +347,7 @@ present in the graph. Because Julia arrays are 1-based, the indexing
 is a bit off. Specifically, entry `k` in the returned array is the
 number of vertices of degree `k-1`.
 """
-function deg_hist{T}(G::SimpleGraph{T})
+function deg_hist(G::SimpleGraph{T}) where {T}
     n = NV(G)
     degs = deg(G)
     result = zeros(Int,n)

--- a/src/simple_euler.jl
+++ b/src/simple_euler.jl
@@ -19,7 +19,7 @@ in the graph (just don't choose an isolated vertex as the first/last).
 
 If no Euler trail/tour exists, an empty list is returned.
 """
-function euler{T}(G::SimpleGraph{T}, u::T, v::T)
+function euler(G::SimpleGraph{T}, u::T, v::T) where {T}
     notrail = T[]
 
     # perform basic checks:
@@ -74,14 +74,14 @@ function euler{T}(G::SimpleGraph{T}, u::T, v::T)
 end
 
 # special case: find an Euler tour from a specified vertex
-function euler{T}(G::SimpleGraph{T},u::T)
+function euler(G::SimpleGraph{T},u::T) where {T}
     return euler(G,u,u)
 end
 
 # special case: find any Euler tour. If the graph is connected, any
 # vertex will do but if there are isolated vertices, we don't want to
 # pick one of those!
-function euler{T}(G::SimpleGraph{T})
+function euler(G::SimpleGraph{T}) where {T}
     if cache_check(G,:euler)
       return cache_recall(G,:euler)
     end
@@ -107,7 +107,7 @@ function euler{T}(G::SimpleGraph{T})
 end
 
 # private helper function for euler()
-function euler_work!{T}(G::SimpleGraph{T}, u::T)
+function euler_work!(G::SimpleGraph{T}, u::T) where {T}
     trail = T[]
 
     while true

--- a/src/simple_girth.jl
+++ b/src/simple_girth.jl
@@ -6,7 +6,7 @@ the vertices on that cycle, or an empty array if `G` is acyclic.
 
 *Warning*: This implementation is quite inefficient.
 """
-function girth_cycle{T}(G::SimpleGraph{T})
+function girth_cycle(G::SimpleGraph{T}) where {T}
   if cache_check(G,:girth_cycle)
     return cache_recall(G,:girth_cycle)
   end


### PR DESCRIPTION
Fixed enough to get it to build. Also removed warnings from Pkg3
The main changes was template functions:
```julia
func{T}(x::T) = ...
```
changed to
```julia
func(x::T) where {T} = ...
```

The other change was adding a catch for every try end statement. The Julia devs agreed that a catch'less try had no use so it was removed.