### PR TITLE
Allow AbstractMatrix when constructing IntGraph

### DIFF
--- a/src/simple_core.jl
+++ b/src/simple_core.jl
@@ -132,7 +132,7 @@ function IntGraph(n::Int)
     return G
 end
 
-function IntGraph(A::Matrix)
+function IntGraph(A::AbstractMatrix)
   r,c = size(A)
   @assert r==c "Matrix must be square"
   @assert A==A' "Matrix must be symmetric"
@@ -153,7 +153,7 @@ end
 `1:n` where `A` is an `n`-by-`n` symmetric matrix specifying the graph's
 adjacency matrix.
 """
-SimpleGraph(A::Matrix) = IntGraph(A)
+SimpleGraph(A::AbstractMatrix) = IntGraph(A)
 
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,6 +27,8 @@ using SimpleGraphs
     A = adjacency(G)
     H = SimpleGraph(A)
     @test G==H
+    H = SimpleGraph(convert(BitMatrix,A))
+    @test G==H
 
     @test get_edge(G,1,2) == get_edge(G,2,1)
 


### PR DESCRIPTION
Changed SimpleGraph(A::Matrix) to SimpleGraph(A::AbstractMatrix) and
IntGraph(A::Matrix) to IntGraph(A::AbstractMatrix).
This is particularly useful when using a BitMatrix for the adjacency
matrix.