### PR TITLE
Fix Base.hash to use only the two-arg method

### DIFF
--- a/src/d_simple_core.jl
+++ b/src/d_simple_core.jl
@@ -316,8 +316,8 @@ function ==(G::DirectedGraph, H::DirectedGraph)
     return isequal(G, H)
 end
 
-function hash(G::DirectedGraph, h::UInt64 = UInt64(0))
-    return hash(G.V, h) + hash(G.N, h)
+function hash(G::DirectedGraph, h::UInt)
+    return hash(G.V, hash(G.N, h))
 end
 
 

--- a/src/simple_core.jl
+++ b/src/simple_core.jl
@@ -388,8 +388,8 @@ end
 
 import Base.hash
 
-function hash(G::UndirectedGraph, h::UInt64 = UInt64(0))
-    return hash(G.V, h) + hash(G.E, h)
+function hash(G::UndirectedGraph, h::UInt)
+    return hash(G.V, hash(G.E, h))
 end
 
 simplify(G::UndirectedGraph) = deepcopy(G)


### PR DESCRIPTION
Generated as part of an ecosystem-wide audit for one-arg hash methods.

`Base.hash` should only be extended via the two-arg method `hash(x, h::UInt)`.
Defining a one-arg `hash(x)` method, or giving the second argument a default
value, can lead to correctness bugs (hash contract violations when the seed
differs from the hard-coded default) and invalidation-related performance
issues. This is particularly necessary for Julia 1.13+ where the default hash
seed value will change.

This PR was generated with the assistance of generative AI.